### PR TITLE
Support runtime Japanese UGUI fonts

### DIFF
--- a/AK_DLL/AK_ModSettings.cs
+++ b/AK_DLL/AK_ModSettings.cs
@@ -94,7 +94,7 @@ namespace AK_DLL
                 if (font == null || DefDatabase<FontDef>.GetNamedSilentFail(font) == null) font = DEFAULT_FONT;
                 return DefDatabase<FontDef>.GetNamedSilentFail(font);
             }
-            set { font = value.defName; }
+            set { font = value?.defName ?? DEFAULT_FONT; }
         }
 
         //记录上次选择的系列以及职业
@@ -249,8 +249,8 @@ namespace AK_DLL
                     {
                         AK_ModSettings.Font = j;
                     }));
-                    Find.WindowStack.Add(new FloatMenu(list));
                 }
+                Find.WindowStack.Add(new FloatMenu(list));
             }
 
             listingStandard.End();

--- a/AK_TypeDef/1AK_TypeDef.csproj
+++ b/AK_TypeDef/1AK_TypeDef.csproj
@@ -40,6 +40,10 @@
       <HintPath>..\Rely\1.6\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\Rely\1.6\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/AK_TypeDef/Unity/Def/FontDef.cs
+++ b/AK_TypeDef/Unity/Def/FontDef.cs
@@ -2,5 +2,10 @@
 {
     public class FontDef : AssetDef
     {
+        public System.Collections.Generic.List<string> systemFontPaths;
+        public int samplingPointSize = 90;
+        public int atlasPadding = 9;
+        public int atlasWidth = 4096;
+        public int atlasHeight = 4096;
     }
 }

--- a/AK_TypeDef/Unity/Utilities_Unity.cs
+++ b/AK_TypeDef/Unity/Utilities_Unity.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using TMPro;
 using UnityEngine;
 using Verse;
@@ -49,8 +50,185 @@ namespace AK_DLL
 
         public static TMP_FontAsset GetUGUIFont(FontDef def)
         {
+            if (def == null)
+            {
+                return null;
+            }
+
+            if (RuntimeSystemFontCache.TryGetUGUIFont(def, out TMP_FontAsset runtimeFont))
+            {
+                return runtimeFont;
+            }
+
+            if (def.assetBundle.NullOrEmpty() || def.modelName.NullOrEmpty())
+            {
+                return null;
+            }
+
             AssetBundle ab = LoadAssetBundle(def.modID, def.assetBundle);
-            return ab.LoadAsset<TMP_FontAsset>(def.modelName);
+            return ab?.LoadAsset<TMP_FontAsset>(def.modelName);
+        }
+
+        private static class RuntimeSystemFontCache
+        {
+            private const string JapaneseFontDefName = "AK_Font_JapaneseJP";
+            private const string JapaneseMediumFontDefName = "AK_Font_JapaneseMediumJP";
+            private const string JapaneseBoldFontDefName = "AK_Font_JapaneseBoldJP";
+            private const int GlyphRenderModeSdFAA = 4165;
+
+            private static readonly Dictionary<string, TMP_FontAsset> CachedFontAssets = new();
+            private static readonly HashSet<string> LoggedMissingFonts = new();
+            private static readonly HashSet<string> LoggedFallbacks = new();
+            private static readonly string[] JapaneseMediumFontPaths =
+            {
+                @"C:\Windows\Fonts\YuGothM.ttc",
+                @"C:\Windows\Fonts\NotoSansJP-VF.ttf",
+                @"C:\Windows\Fonts\meiryo.ttc",
+                @"C:\Windows\Fonts\BIZ-UDGothicR.ttc",
+                @"C:\Windows\Fonts\msgothic.ttc"
+            };
+            private static readonly string[] JapaneseBoldFontPaths =
+            {
+                @"C:\Windows\Fonts\YuGothB.ttc",
+                @"C:\Windows\Fonts\meiryob.ttc",
+                @"C:\Windows\Fonts\BIZ-UDGothicB.ttc",
+                @"C:\Windows\Fonts\NotoSansJP-VF.ttf",
+                @"C:\Windows\Fonts\msgothic.ttc"
+            };
+
+            public static bool TryGetUGUIFont(FontDef def, out TMP_FontAsset fontAsset)
+            {
+                fontAsset = null;
+
+                List<string> fontPaths = def.systemFontPaths;
+                if ((fontPaths == null || fontPaths.Count == 0) && IsBuiltInJapaneseRuntimeFont(def.defName))
+                {
+                    fontPaths = BuiltInJapaneseRuntimeFontPaths(def.defName).ToList();
+                }
+
+                if (fontPaths == null || fontPaths.Count == 0)
+                {
+                    return false;
+                }
+
+                if (CachedFontAssets.TryGetValue(def.defName, out fontAsset) && fontAsset != null)
+                {
+                    return true;
+                }
+
+                string fontPath = fontPaths.FirstOrDefault(File.Exists);
+                if (fontPath == null)
+                {
+                    if (LoggedMissingFonts.Add(def.defName))
+                    {
+                        Log.Warning($"[MIS] No system font found for FontDef {def.defName}.");
+                    }
+                    return false;
+                }
+
+                try
+                {
+                    Font font = new(fontPath);
+                    fontAsset = CreateFontAsset(font, def);
+                    fontAsset.name = $"{def.defName}_{Path.GetFileNameWithoutExtension(fontPath)}";
+                    fontAsset.atlasPopulationMode = AtlasPopulationMode.Dynamic;
+                    CachedFontAssets[def.defName] = fontAsset;
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning($"[MIS] Failed to create runtime font for FontDef {def.defName}: {ex.GetType().Name}: {ex.Message}");
+                    CachedFontAssets.Remove(def.defName);
+                    fontAsset = null;
+                    return false;
+                }
+            }
+
+            private static bool IsBuiltInJapaneseRuntimeFont(string defName)
+            {
+                return defName == JapaneseFontDefName ||
+                       defName == JapaneseMediumFontDefName ||
+                       defName == JapaneseBoldFontDefName;
+            }
+
+            private static IEnumerable<string> BuiltInJapaneseRuntimeFontPaths(string defName)
+            {
+                return defName == JapaneseBoldFontDefName ? JapaneseBoldFontPaths : JapaneseMediumFontPaths;
+            }
+
+            private static TMP_FontAsset CreateFontAsset(Font font, FontDef def)
+            {
+                Type glyphRenderModeType = GetGlyphRenderModeType();
+                MethodInfo createFontAsset = GetDetailedCreateFontAssetMethod(glyphRenderModeType);
+                if (createFontAsset != null)
+                {
+                    try
+                    {
+                        object glyphRenderMode = Enum.ToObject(glyphRenderModeType, GlyphRenderModeSdFAA);
+                        return (TMP_FontAsset)createFontAsset.Invoke(null, new[]
+                        {
+                            font,
+                            def.samplingPointSize,
+                            def.atlasPadding,
+                            glyphRenderMode,
+                            def.atlasWidth,
+                            def.atlasHeight,
+                            AtlasPopulationMode.Dynamic,
+                            true
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        if (LoggedFallbacks.Add(def.defName))
+                        {
+                            Log.Warning($"[MIS] Failed to create detailed runtime font for FontDef {def.defName}; falling back to TMP defaults: {ex.GetType().Name}: {ex.Message}");
+                        }
+                    }
+                }
+
+                return TMP_FontAsset.CreateFontAsset(font);
+            }
+
+            private static Type GetGlyphRenderModeType()
+            {
+                Type type = Type.GetType("UnityEngine.TextCore.LowLevel.GlyphRenderMode, UnityEngine.TextCoreFontEngineModule");
+                if (type != null)
+                {
+                    return type;
+                }
+
+                return AppDomain.CurrentDomain.GetAssemblies()
+                    .Select(assembly => assembly.GetType("UnityEngine.TextCore.LowLevel.GlyphRenderMode"))
+                    .FirstOrDefault(foundType => foundType != null);
+            }
+
+            private static MethodInfo GetDetailedCreateFontAssetMethod(Type glyphRenderModeType)
+            {
+                if (glyphRenderModeType == null)
+                {
+                    return null;
+                }
+
+                return typeof(TMP_FontAsset).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .FirstOrDefault(method =>
+                    {
+                        if (method.Name != nameof(TMP_FontAsset.CreateFontAsset))
+                        {
+                            return false;
+                        }
+
+                        ParameterInfo[] parameters = method.GetParameters();
+                        return parameters.Length == 8 &&
+                               parameters[0].ParameterType == typeof(Font) &&
+                               parameters[1].ParameterType == typeof(int) &&
+                               parameters[2].ParameterType == typeof(int) &&
+                               parameters[3].ParameterType == glyphRenderModeType &&
+                               parameters[4].ParameterType == typeof(int) &&
+                               parameters[5].ParameterType == typeof(int) &&
+                               parameters[6].ParameterType == typeof(AtlasPopulationMode) &&
+                               parameters[7].ParameterType == typeof(bool);
+                    });
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- allow `FontDef` entries to create TMP UGUI fonts from local system font files
- add built-in runtime fallback names for Japanese medium/bold font options
- fix the font selector menu so it opens once after all font options are collected

## Notes
This keeps existing asset-bundle based fonts working. Runtime font defs can provide `systemFontPaths`, and the built-in Japanese runtime def names use common Windows Japanese fonts when available.

## Verification
- `dotnet build AK_TypeDef\1AK_TypeDef.csproj -c Release /p:SolutionDir=<temp>\`
- `dotnet build AK_DLL\AK_Library.csproj -c Release /p:SolutionDir=<temp>\`